### PR TITLE
Dogepedia Stubs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -254,7 +254,7 @@ disableHugoGeneratorInject = false
     [[menu.main]]
     identifier = "faq"
     name       = "FAQ"
-    url        = "dogepedia/faq"
+    url        = "dogepedia/#faq"
     parent = "dogepedia"
     weight     = 5
 
@@ -268,14 +268,14 @@ disableHugoGeneratorInject = false
     [[menu.main]]
     identifier = "how-tos"
     name       = "How Tos"
-    url        = "dogepedia/how-tos"
+    url        = "dogepedia/#howto"
     parent = "dogepedia"
     weight     = 5
     
     [[menu.main]]
     identifier = "documentation"
     name       = "Documentation"
-    url        = "dogepedia/documentation"
+    url        = "dogepedia/#documentation"
     parent = "dogepedia"
     weight     = 5
     

--- a/content/dogepedia.md
+++ b/content/dogepedia.md
@@ -1,7 +1,76 @@
 +++
 title = "Dogepedia"
-date = "2014-04-09"
+date = "2021-10-22"
 aliases = ["dogepedia"]
 [ author ]
   name = "Dogecoin"
 +++
+ 
+Dogepedia is the resource containing Documentation, Guides, FAQs and Resources related to Dogecoin. The place to be for all shibes trying to learn about Dogecoin and crypto. Such knowledge! Much wow!
+
+## Documentation {#documentation}
+***
+### Dogecoin
+The basics. Learn what Dogecoin is, and how it works.
+- [What is Dogecoin?](/dogepedia/articles/what-is-dogecoin)
+- [What is the history of Dogecoin?](/dogepedia/articles/history-of-dogecoin)
+- [How does Dogecoin work?](/dogepedia/articles/how-does-dogecoin-work)
+- [Who owns and controls the Dogecoin network?](/dogepedia/articles/who-owns-dogecoin)
+- [I want some Dogecoin! How can I get it?](/dogepedia/articles/get-dogecoin)
+
+### Wallets
+Your journey with Dogecoin might start here. A wallet application allows you to save and spend your Doge.
+- [How do I get a wallet?](/dogepedia/articles/how-do-i-get-a-wallet)
+- [How do I backup my wallet?](/dogepedia/articles/how-to-backup-a-wallet)
+- [What are the benefits of a hardware wallet, and how to use it with Doge?](/dogepedia/articles/dogecoin-hardware-wallets)
+- [How do I recover a lost wallet?](/dogepedia/articles/recover-a-lost-wallet)
+- [What is a wallet, really?](/dogepedia/articles/what-is-a-wallet)
+
+### Using your Doge
+Dogecoin is a cryptocurrency, and you can use it to send and receive payments.
+- [How do I send and receive Dogecoin?](/dogepedia/articles/send-and-receive-dogecoin)
+- [How can I use Dogecoin to buy stuff from my favorite stores?](/dogepedia/articles/using-dogecoin-in-a-store)
+- [Is my privacy protected while using Dogecoin?](/dogepedia/articles/dogecoin-and-privacy)
+
+### Community and Ecosystem
+- [How can I join the Dogecoin community?](/dogepedia/articles/join-the-dogecoin-community)
+- [What is the Dogecoin Foundation?](/dogepedia/articles/what-is-the-dogecoin-foundation)
+- [How can I help?](/dogepedia/articles/how-can-i-help-doge)
+- [How can my business accept Dogecoin?](/dogepedia/articles/how-can-my-business-accept-dogecoin)
+- [What merchants currently accept Dogecoin?](/dogepedia/articles/merchants-accepting-doge)
+- [What are some charities that accept Dogecoin?](/dogepedia/articles/charities-accepting-doge)
+- [What is Dogecoin Folding @ Home?](/dogepedia/articles/dogecoin-folding-at-home)
+- [Is xxx project affiliated with The Dogecoin Foundation?](/dogepedia/articles/is-this-project-affiliated-with-dogecoin-foundation)
+
+### Running Nodes, Mining, and More
+For the technical shibe - but not only. Learn how the Dogecoin network actually works, and how to support it.
+- [What is a blockchain?](/dogepedia/articles/what-is-a-blockchain)
+- [What is a node and why is it important? Do I need to run one?](/dogepedia/articles/what-is-a-node)
+- [What is a miner?](/dogepedia/articles/what-is-a-miner)
+- [What is a mining pool?](/dogepedia/articles/what-is-a-mining-pool)
+- [How do I setup a node?](/dogepedia/how-tos/operating-a-node)
+- [How can I mine Dogecoin?](/dogepedia/how-tos/mining-dogecoin)
+
+### Development
+Dogecoin is useful, personable, welcoming, and reliable: and it is evolving.
+- [Who are the current Dogecoin developers?](/dogepedia/articles/dogecoin-developers)
+- [How can I become a Dogecoin developer?](/dogepedia/articles/becoming-a-dogecoin-developer)
+- [Is there a roadmap?](/dogepedia/articles/dogecoin-roadmap)
+
+## How-Tos {#howto}
+For all the shibes who want to learn new tricks.
+***
+- [Operating a Dogecoin Node](/dogepedia/how-tos/operating-a-node)
+- [Mining Dogecoin](/dogepedia/how-tos/mining-dogecoin)
+- [Making Memes](/dogepedia/how-tos/making-memes)
+
+## FAQ & FUD {#faq}
+Let's fight against the disinformation surrounding Dogecoin! Much wow!
+***
+- [Dogecoin is just a joke!](/dogepedia/faq/dogecoin-is-a-joke)
+- [Dogecoin has no utility!](/dogepedia/faq/dogecoin-has-no-utility)
+- [Dogecoin has no developers!](/dogepedia/faq/dogecoin-has-no-developers)
+- [Why don't the devs burn some of the supply?](/dogepedia/faq/dogecoin-and-coin-burning)
+- [Why don't the devs put a cap on Dogecoin?](/dogepedia/faq/putting-a-cap-on-dogecoin)
+- [Is it true that one person holds 28% of the total supply?](/dogepedia/faq/dogecoin-whale-wallets)
+- [Dogecoin is inflationary, while other cryptos aren't!](/dogepedia/faq/dogecoin-inflation)

--- a/content/dogepedia/_index.md
+++ b/content/dogepedia/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Dogepedia Index"
+date = "2021-10-22"
+draft = false
+[_build]
+  render = "never"
+  list = "never" 
++++
+{{/* Remove this if we switch to the auto index generation */}}

--- a/content/dogepedia/articles/becoming-a-dogecoin-developer.md
+++ b/content/dogepedia/articles/becoming-a-dogecoin-developer.md
@@ -1,0 +1,8 @@
++++
+title = "How can I become a Dogecoin developer?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+How can shibes get involved with Dogecoin development?

--- a/content/dogepedia/articles/charities-accepting-doge.md
+++ b/content/dogepedia/articles/charities-accepting-doge.md
@@ -1,0 +1,8 @@
++++
+title = "What are some charities that accept Dogecoin?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Lists to charities we can recommend accepting Doge.

--- a/content/dogepedia/articles/dogecoin-and-privacy.md
+++ b/content/dogepedia/articles/dogecoin-and-privacy.md
@@ -1,0 +1,8 @@
++++
+title = "Dogecoin and Privacy"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Are Dogecoin transactions anonymous? Are there ways shibes can protect their privacy?

--- a/content/dogepedia/articles/dogecoin-developers.md
+++ b/content/dogepedia/articles/dogecoin-developers.md
@@ -1,0 +1,8 @@
++++
+title = "Who are the current Dogecoin developers?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+An introduction to the current developers, and a view on the expanded development community around Dogecoin.

--- a/content/dogepedia/articles/dogecoin-folding-at-home.md
+++ b/content/dogepedia/articles/dogecoin-folding-at-home.md
@@ -1,0 +1,8 @@
++++
+title = "What is Dogecoin Folding @ Home?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Describe the Dogecoin Folding @ Home - but before including this, double check with the current project maintainers. This article could be contributed by them.

--- a/content/dogepedia/articles/dogecoin-hardware-wallets.md
+++ b/content/dogepedia/articles/dogecoin-hardware-wallets.md
@@ -1,0 +1,8 @@
++++
+title = "What are the benefits of a hardware wallet, and how to use it with Doge?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+What is a hardware wallet, and what are its advantages? List several options available. Discuss eventual legal/affiliation issues with the foundation.

--- a/content/dogepedia/articles/dogecoin-roadmap.md
+++ b/content/dogepedia/articles/dogecoin-roadmap.md
@@ -1,0 +1,8 @@
++++
+title = "Is there a roadmap?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Dogecoin and roadmaps.

--- a/content/dogepedia/articles/get-dogecoin.md
+++ b/content/dogepedia/articles/get-dogecoin.md
@@ -1,0 +1,8 @@
++++
+title = "How can I get Dogecoin?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+ 
+Several ways to get your hands on Doge - from exchanges, tipping, or from projects like Dogecoin Folding @ Home. This could be broken down in subarticles, if needed.

--- a/content/dogepedia/articles/history-of-dogecoin.md
+++ b/content/dogepedia/articles/history-of-dogecoin.md
@@ -1,0 +1,10 @@
++++
+title = "The History of Dogecoin"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+ 
+The history of Dogecoin - from Billy and Jackson's quasi-mythical launch to our times, passing through Dogecars and Jamaican bobsled teams, generosity and insanity. Picture of a shibe-historian with a long beard at the top. 
+
+Consult Billy and the current developers, and read through Sporklin's post history, which is a repository on the history of Dogecoin.

--- a/content/dogepedia/articles/how-can-i-help-doge.md
+++ b/content/dogepedia/articles/how-can-i-help-doge.md
@@ -1,0 +1,8 @@
++++
+title = "How can I help?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Things users can do to contribute and support to Dogecoin.

--- a/content/dogepedia/articles/how-can-my-business-accept-dogecoin.md
+++ b/content/dogepedia/articles/how-can-my-business-accept-dogecoin.md
@@ -1,0 +1,8 @@
++++
+title = "How can my business accept Dogecoin?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Things merchants can do to allow Dogecoin payments.

--- a/content/dogepedia/articles/how-do-i-get-a-wallet.md
+++ b/content/dogepedia/articles/how-do-i-get-a-wallet.md
@@ -1,0 +1,8 @@
++++
+title = "How do I get a Dogecoin wallet?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+ 
+Where and how to get a Dogecoin wallet, and the several options available to shibes.

--- a/content/dogepedia/articles/how-does-dogecoin-work.md
+++ b/content/dogepedia/articles/how-does-dogecoin-work.md
@@ -1,0 +1,8 @@
++++
+title = "How Does Dogecoin Work?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+ 
+A high-level overview of how Dogecoin works. ELI5 style.

--- a/content/dogepedia/articles/how-to-backup-a-wallet.md
+++ b/content/dogepedia/articles/how-to-backup-a-wallet.md
@@ -1,0 +1,8 @@
++++
+title = "How do I backup a Dogecoin wallet?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Backups, backups, and backups!

--- a/content/dogepedia/articles/is-this-project-affiliated-with-dogecoin-foundation.md
+++ b/content/dogepedia/articles/is-this-project-affiliated-with-dogecoin-foundation.md
@@ -1,0 +1,7 @@
++++
+title = "Is xxx project affiliated with The Dogecoin Foundation?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+

--- a/content/dogepedia/articles/join-the-dogecoin-community.md
+++ b/content/dogepedia/articles/join-the-dogecoin-community.md
@@ -1,0 +1,8 @@
++++
+title = "How can I join the Dogecoin community?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Talk about reddit, social networks, and how users can participate.

--- a/content/dogepedia/articles/merchants-accepting-doge.md
+++ b/content/dogepedia/articles/merchants-accepting-doge.md
@@ -1,0 +1,8 @@
++++
+title = "What merchants currently accept Dogecoin?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Lists to shops and companies accepting Doge. Link to directories?

--- a/content/dogepedia/articles/recover-a-lost-wallet.md
+++ b/content/dogepedia/articles/recover-a-lost-wallet.md
@@ -1,0 +1,8 @@
++++
+title = "How do I recover a lost wallet?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Offer solutions to common problems. For more intricate situations, forward to r/dogeducation.

--- a/content/dogepedia/articles/send-and-receive-dogecoin.md
+++ b/content/dogepedia/articles/send-and-receive-dogecoin.md
@@ -1,0 +1,8 @@
++++
+title = "How do I send and receive Dogecoin?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+How can a shibe spend and use his/her Dogecoin? Explain basic functionality and concepts.

--- a/content/dogepedia/articles/using-dogecoin-in-a-store.md
+++ b/content/dogepedia/articles/using-dogecoin-in-a-store.md
@@ -1,0 +1,8 @@
++++
+title = "How can I use Dogecoin to buy stuff from my favorite stores?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Options a shibe has to spend Dogecoin in a store that supports crypto payments and in one that does not (directly).

--- a/content/dogepedia/articles/what-is-a-blockchain.md
+++ b/content/dogepedia/articles/what-is-a-blockchain.md
@@ -1,0 +1,8 @@
++++
+title = "What is a blockchain?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+A fairly accessible introduction to what a blockchain is.

--- a/content/dogepedia/articles/what-is-a-miner.md
+++ b/content/dogepedia/articles/what-is-a-miner.md
@@ -1,0 +1,8 @@
++++
+title = "What is a miner?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+A fairly accessible introduction to what a miner is, and the role of miners in the network.

--- a/content/dogepedia/articles/what-is-a-mining-pool.md
+++ b/content/dogepedia/articles/what-is-a-mining-pool.md
@@ -1,0 +1,8 @@
++++
+title = "What is a mining pool?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+What is a mining pool, and does it relate to individual miners?

--- a/content/dogepedia/articles/what-is-a-node.md
+++ b/content/dogepedia/articles/what-is-a-node.md
@@ -1,0 +1,8 @@
++++
+title = "What is a node and why is it important? Do I need to run one?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+A fairly accessible introduction to what a node is, and the role of nodes in the network.

--- a/content/dogepedia/articles/what-is-a-wallet.md
+++ b/content/dogepedia/articles/what-is-a-wallet.md
@@ -1,0 +1,8 @@
++++
+title = "What is a wallet, really?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+It would be important to explain the difference between a wallet and a wallet application that is used to interact with a wallet and operate with it.

--- a/content/dogepedia/articles/what-is-dogecoin.md
+++ b/content/dogepedia/articles/what-is-dogecoin.md
@@ -1,0 +1,10 @@
++++
+title = "What is Dogecoin"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+ 
+Let's talk about what Dogecoin really is. Is it its blockchain? Its community? Its future developments? Like all good cryptos, Dogecoin will need to be dynamic and reinvent itself, but always staying true to its origins of being the most fun crypto.
+
+The Dogecoin Manifest can be a good source for this article.

--- a/content/dogepedia/articles/what-is-the-dogecoin-foundation.md
+++ b/content/dogepedia/articles/what-is-the-dogecoin-foundation.md
@@ -1,0 +1,8 @@
++++
+title = "What is the Dogecoin Foundation?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+The difference between the Dogecoin Foundation and Dogecoin itself. Why the two are parallel, not coinciding.

--- a/content/dogepedia/articles/who-owns-dogecoin.md
+++ b/content/dogepedia/articles/who-owns-dogecoin.md
@@ -1,0 +1,8 @@
++++
+title = "Who owns and controls the Dogecoin Network?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+ 
+No owners. Permissionless. Free. For all shibes.

--- a/content/dogepedia/faq/dogecoin-and-coin-burning.md
+++ b/content/dogepedia/faq/dogecoin-and-coin-burning.md
@@ -1,0 +1,8 @@
++++
+title = "Dogecoin and coin burning"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Dogecoin is not a speculative asset, and it does not need coin burning mechanisms new tokens and other chains have attempted to implement to artificially inflate their prices.

--- a/content/dogepedia/faq/dogecoin-has-no-developers.md
+++ b/content/dogepedia/faq/dogecoin-has-no-developers.md
@@ -1,0 +1,13 @@
++++
+title = "Dogecoin has no developers!"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Oh yes it does, and it always had. Just, since Dogecoin main purpose has been to be a currency since its birth, and since it was forked from Litecoin and then reforked from Bitcoin, with changed parameters to make it more suitable as a cryptocurrency, it means it inherited already feature-complete code bases. So, for many years, instead of having new shiny features, the development team worked mostly as maintainers of what was already there. Not once, in its history, Dogecoin did not have a group of developers working on it.
+
+In the future, the plan is to focus more efforts and resources to enhance Dogecoin, and make it fullfill its aim to become a crypto of the people also in its technical implementation. This will require a combination of part time contributors, volunteers, but also full time developers and engineers. Alongside, the foundation and the advisors will provide a "roadmap" to aim at possible goals: roadmap that will never be authoritative or normative, but an indication of where to go.
+
+
+

--- a/content/dogepedia/faq/dogecoin-has-no-utility.md
+++ b/content/dogepedia/faq/dogecoin-has-no-utility.md
@@ -1,0 +1,14 @@
++++
+title = "Dogecoin has no utility!"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Oh yes it does, and it always had. In fact, one could say it is one of the few cryptocurrencies that has been used for its main purpose from day one. Dogecoin was first meant to be a joke - and it served and will serve this purpose very well - but it almost immediately became a means to tip and encourage others to go and achieve something - the Dogecoin car, the Jamaican bobsled team, the water wells in Kenya, and many more crazy initiatives the community supported over the years. As a tipping currency, thanks to its low fees and speed of transactions in comparison to competing chains for a long part of its existence, Dogecoin has never stopped working for its intended use. 
+
+Over the years, it became possible to use Dogecoin and spend it in online stores. The past 2 years have seen an explosion in the adoption, with Dogecoin payment integrations provided by third parties like Bitpay and Coinbase and several providers providing prepaid cards supporting Dogecoin as a funding source. Shops can also integrate directly with the Dogecoin blockchain, and the Foundation, alongside the ecosystem of developers, is planning to facilitate this further by  creating libraries that will streamline and standardize implementations.
+
+Development is ongoing to enhance Dogecoin and make it fullfill its original promises while being competitive with other cryptos - and thus find new purposes and uses.
+
+

--- a/content/dogepedia/faq/dogecoin-inflation.md
+++ b/content/dogepedia/faq/dogecoin-inflation.md
@@ -1,0 +1,11 @@
++++
+title = "Dogecoin Inflation"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Dogecoin has a fixed yearly issuance of 5.5 billion coins. This means that each year, the rate of inflation decreases when considered against the total supply, and in a very predictable way, making Dogecoin ideal to be used as a currency. Expand on this.
+
+- https://investorplace.com/2021/02/dogecoin-has-an-inflationary-supply-trait-making-it-ideal-as-a-cryptocurrency/
+- https://arstechnica.com/information-technology/2014/02/dogecoin-to-allow-annual-inflation-of-5-billion-coins-each-year-forever/

--- a/content/dogepedia/faq/dogecoin-is-a-joke.md
+++ b/content/dogepedia/faq/dogecoin-is-a-joke.md
@@ -1,0 +1,14 @@
++++
+title = "Dogecoin is a joke!"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Dogecoin was born as a joke - and this side of it, its sense of fun, should never go away. This post should get inspiration mostly from Sporklin's and Billy's statements on the topic, I believe. Sporklin, a staunch defender of Dogecoin, dedicated several posts to answer this statement, at the same time contextualizing and using it as a point of strength.
+
+- https://old.reddit.com/r/dogecoin/comments/kfizst/dogepound/gg9kxe9/
+- https://www.reddit.com/r/dogecoindev/comments/lhtqt1/comment/gn3wz8g/?utm_source=share&utm_medium=web2x&context=3
+
+
+

--- a/content/dogepedia/faq/dogecoin-whale-wallets.md
+++ b/content/dogepedia/faq/dogecoin-whale-wallets.md
@@ -1,0 +1,11 @@
++++
+title = "A whale holds nearly 30% of Dogecoin supply! Is this true?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+The whale in question is an exchange, and so are most of the top holders in the Dogecoin network. As a matter of fact, the infamous largest whale is likely to be Robin Hood - which means it represents assets of tens of thousands of retails investors. 
+
+- Use Patrick's thread for expanding on this: https://www.reddit.com/r/dogecoin/comments/lngacy/many_fud_lets_fix_that_wow/. 
+- There is no need to specify which exchanges hold which wallets, but do explain the combination of hot/cold wallets and why exchanges use them.

--- a/content/dogepedia/faq/putting-a-cap-on-dogecoin.md
+++ b/content/dogepedia/faq/putting-a-cap-on-dogecoin.md
@@ -1,0 +1,10 @@
++++
+title = "Can you put a cap on Dogecoin?"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+Dogs should wear no hats, and Doge is a dog, after all. The annual issuance is needed to pay miners and keep the network secure. Other chains, like Bitcoin, which theoretically will see their yearly issuance stop completely in 2140, will need to find a way to secure their network at that time (if it will still exist) - or they will need to change completely the design of their consensus mechanism. 
+
+Other PoS cryptos also have unlimited supply - but nobody talks about it, for some reason.

--- a/content/dogepedia/how-tos/making-memes.md
+++ b/content/dogepedia/how-tos/making-memes.md
@@ -1,0 +1,8 @@
++++
+title = "Making Memes"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+The power of Dogecoin lies in memes. How to make them? What makes a good meme?

--- a/content/dogepedia/how-tos/mining-dogecoin.md
+++ b/content/dogepedia/how-tos/mining-dogecoin.md
@@ -1,0 +1,8 @@
++++
+title = "Mining Dogecoin"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+A guide for those who want to mine Dogecoin. Why GPU mining is not very convenient. ASIC miners. Mining pools.

--- a/content/dogepedia/how-tos/operating-a-node.md
+++ b/content/dogepedia/how-tos/operating-a-node.md
@@ -1,0 +1,8 @@
++++
+title = "Operate a Dogecoin Node"
+date = "2021-10-22"
+[ author ]
+  name = "Dogecoin"
++++
+
+A guide for Dogecoin Node operators.

--- a/content/resources.md
+++ b/content/resources.md
@@ -1,7 +1,29 @@
 +++
 title = "Resources"
-date = "2014-04-09"
+date = "2021-10-22"
 aliases = ["dogepedia/resources"]
 [ author ]
   name = "Dogecoin"
 +++
+
+A list of resources created by shibes that can be useful to work with Dogecoin and to research it.
+
+### Tools to Monitor and Study Dogecoin and its Network
+- [SoChain - Dogecoin chain explorer.](https://sochain.com/DOGE)
+- [Dogechain - Dogecoin chain explorer.](https://dogechain.info/)
+- [Blockcypher - Dogecoin chain explorer.](https://live.blockcypher.com/doge/)
+- [Blockshibe - monitor the work of miners and mining pools. Developed by Patrick Lodder, Dogecoin Core developer.](https://blockshibe.net)
+- [Blockchair - monitor the number and versions of Dogecoin nodes in the network.](https://blockchair.com/dogecoin/nodes)
+
+### Shop Directories
+- [ShopDoge.xyz - a directory of shops accepting Dogecoin.](https://shopdoge.xyz/)
+- [Cryptwerk - a directory of shops accepting Dogecoin.](https://cryptwerk.com/pay-with/doge/)
+
+### Third Party Providers of Payment Integrations
+- [Coinbase - integration for Wordpress and Shopify.](https://commerce.coinbase.com/integrate)
+- [Bitpay - integrations for multiple platforms.](https://bitpay.com/integrations/)
+
+### Communities
+- [The Official Dogecoin community on reddit.](https://reddit.com/r/dogecoin)
+- [The Official Dogecoin development community on reddit.](https://reddit.com/r/dogecoindev)
+- [The Official Dogecoin community to help educating new and old shibes.](https://reddit.com/r/dogeducation)


### PR DESCRIPTION
These first commits include the following:

- Setup of the Dogepedia index page, with Document, FAQ, and How-Tos sections
- Updated the menu to link to sub section of the page instead than new pages (for now: if this grows too big, we can split again)
- Disabled auto-index generation in the new content/dogepedia directory since we are using content/dogepedia.md for now
- Initial article stubs
- Initial resources section