### PR TITLE
add .hugo_build.lock, .DS_Store, .vscode and node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 public
 resources/_gen
 .idea
+.vscode
+.hugo_build.lock
+node_modules/
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
.hugo_build.lock is a new feature to deal with concurrency while running multiple instances of hugo server but it's intrusive when switching between branches on local imo. 

adding .vscode and node_modules preemptively in anticipation of merging redesign. 

indifferent to .vscode as i don't use any debuggers, linters, plugins but have found it bothersome in the past.

.DS_Store to prevent mac users from adding extraneous files to content and root dirs.