### PR TITLE
Adjustments to articles related to the "lost wallet" one

### DIFF
--- a/content/dogepedia/articles/how-to-backup-a-wallet.md
+++ b/content/dogepedia/articles/how-to-backup-a-wallet.md
@@ -15,8 +15,35 @@ Most Dogecoin holders use some kind of [*wallet application*](/dogepedia/article
 
 Dogecoin Core, the software used to run a Dogecoin node, is often used as a wallet application. In order to create a backup with Dogecoin Core, follow these steps:
 
-- (Optional, but recommended) First, encrypt your wallet. To do so, go to Settings -> Encrypt wallet. You will be asked to enter a password. It is crucial that you store this password somewhere safe and that you never lose it. Without it, you will be unable to access the funds in your encrypted wallet. On the other hand, this password adds an extra layer of security to your backup. Without it, even if an attacker gains access to your wallet file, he will still be unable to spend your Dogecoin.
+- (Optional, but recommended) First, encrypt your wallet. To do so, go to Settings -> Encrypt wallet. You will be asked to enter a password. It is crucial that you store this password somewhere safe and that you never lose it. Without it, you would be unable to access the funds in your encrypted wallet. 
+
+   On the other hand, this password adds an extra layer of security to your backup. Without it, even if an attacker gains access to your wallet file, he will still be unable to spend your Dogecoin, unless he succeeds in brute forcing or guessing the encryption password.
 - Go to File -> Backup Wallet. This will generate a wallet.dat file, which stores a list of all the key pairs you have used. Restoring this file will give you access to your Dogecoin. Store it somewhere safe, in a device not connected to the internet.
+
+Whenever you generate a new public address with Dogecoin Core or you spend coins, it is recommended that you create a new backup, as the old wallet.dat files might not contain a copy of the private key associated with the new public address or with possible change addresses - thus, upon restoring the wallet, you might be missing part of your Dogecoin.
+
+*Remember: whoever gains access to the wallet.dat file will be able to spend your Dogecoin*.
+
+#### Saving Private Keys and Public Keys in a Text File
+The wallet.dat file is not a plain-text file. It is a binary file that requires a copy of Dogecoin Core to be used and read. For this reason, it might be a good idea to create a plain text backup of your wallet, containing a list of all private and public keys currently in use by Dogecoin Core. In order to do so:
+
+- Go to Help -> Debug Window
+- Select the Console tab
+- If your wallet is encrypted, temporarily decrypt it using the *walletpassphrase* command, specifying the amount of seconds after which the decrypted copy will be deleted.
+	```console
+    walletpassphrase "yourpasswordhere" 120
+    ```
+    The console should return "null".
+- Dump your wallet in a file using the *dumpwallet* command and specifying the path to the file.
+	```console
+    dumpwallet "/Users/Cheemz/BackupDirectory/mywallet"
+    null
+    ```
+    The console should return "null".
+- Optional: encrypt the wallet file. You can use your operating system's disk encryption options or a zip program allowing you to password-protect a file and encrypt it with a secure algorithm (AES256, for example). Make sure the password used for the encryption is impossible to forget or stored properly as well.
+- Copy the backup in multiple safe locations, NOT connected to the Internet. 
+
+*Remember: whoever gains access to the plain-text wallet file will be able to spend your Dogecoin*.
 
 ### Wallet Backups with Wallets Using Seed Phrases
 

--- a/content/dogepedia/articles/how-to-backup-a-wallet.md
+++ b/content/dogepedia/articles/how-to-backup-a-wallet.md
@@ -25,7 +25,7 @@ Whenever you generate a new public address with Dogecoin Core or you spend coins
 *Remember: whoever gains access to the wallet.dat file will be able to spend your Dogecoin*.
 
 #### Saving Private Keys and Public Keys in a Text File
-The wallet.dat file is not a plain-text file. It is a binary file that requires a copy of Dogecoin Core to be used and read. For this reason, it might be a good idea to create a plain text backup of your wallet, containing a list of all private and public keys currently in use by Dogecoin Core. In order to do so:
+The wallet.dat file is not a plain-text file. It is a BDB (Berkley Database). For this reason, it might be a good idea to create a plain text backup of your wallet, containing a list of all private and public keys currently in use by Dogecoin Core. In order to do so:
 
 - Go to Help -> Debug Window
 - Select the Console tab

--- a/content/dogepedia/articles/how-to-backup-a-wallet.md
+++ b/content/dogepedia/articles/how-to-backup-a-wallet.md
@@ -17,7 +17,7 @@ Dogecoin Core, the software used to run a Dogecoin node, is often used as a wall
 
 - (Optional, but recommended) First, encrypt your wallet. To do so, go to Settings -> Encrypt wallet. You will be asked to enter a password. It is crucial that you store this password somewhere safe and that you never lose it. Without it, you would be unable to access the funds in your encrypted wallet. 
 
-   On the other hand, this password adds an extra layer of security to your backup. Without it, even if an attacker gains access to your wallet file, he will still be unable to spend your Dogecoin, unless he succeeds in brute forcing or guessing the encryption password.
+   On the other hand, this password adds an extra layer of security to your backup. Without it, even if an attacker gains access to your wallet file, they will still be unable to spend your Dogecoin, unless they succeed in brute forcing or guessing the encryption password.
 - Go to File -> Backup Wallet. This will generate a wallet.dat file, which stores a list of all the key pairs you have used. Restoring this file will give you access to your Dogecoin. Store it somewhere safe, in a device not connected to the internet.
 
 Whenever you generate a new public address with Dogecoin Core or you spend coins, it is recommended that you create a new backup, as the old wallet.dat files might not contain a copy of the private key associated with the new public address or with possible change addresses - thus, upon restoring the wallet, you might be missing part of your Dogecoin.

--- a/content/dogepedia/articles/what-is-a-wallet.md
+++ b/content/dogepedia/articles/what-is-a-wallet.md
@@ -5,8 +5,14 @@ date = "2021-10-22"
   name = "Dogecoin"
 +++
 
-A wallet is a set of private keys that gives you access to the control of certain coins on the blockchain ledger. When you spend a coin, control of that coin is transferred from being controlled by your keys to being controlled by someone else's keys. Wallets simply hold your keys and tell you how many coins they control. 
+A wallet is a set of private keys that gives you access to the control of certain coins on the blockchain ledger. When you spend a coin, control of that coin is transferred from being controlled by your keys to being controlled by someone else's keys. 
 
-A wallet app is an application which manages these keys, reports these amounts, and facilitates the transfer of amounts of coins between addresses. Some store your keys locally, others use their own keys on a remote server (which is less safe). Just remember: *whoever has the keys controls the coins*.  
+A *wallet app* (often referred to simply as a "wallet") is an application which manages these keys, reports these amounts, and facilitates the transfer of amounts of coins between addresses. Some wallet apps store your keys locally; others store the keys on a remote server (which is less safe). Just remember: *whoever has the keys controls the coins*. 
 
-While some "custodial" services, where coins that are "yours" are held under their keys may indeed be trustworthy, keep in mind that many are not, and unless you hold the keys, ultimately, the only thing keeping whoever *does* hold the keys from transferring your coins, is trust. 
+While some "custodial" services, where coins that are "yours" are held under the service provider's keys may be trustworthy, keep in mind that many are not. Unless you hold the keys, ultimately, the only thing keeping whoever *does* hold the keys from transferring your coins is trust. 
+
+**It is important to understand that unlike a physical wallet, which holds actual notes and coins, crypto wallets do not really "store" your crypto (in this case, Dogecoin) locally. They are storing a collection of private keys and private addresses used to access your Dogecoin, which is actually "living" on the [blockchain](/dogepedia/articles/what-is-a-blockchain/).** The blockchain is a digital ledger of transactions that is duplicated and distributed throughout an entire network of computers called [nodes](/dogepedia/articles/what-is-a-node/). You could have several wallet applications using the same private keys, and you would be able to access and spend your Dogecoin from each of these apps.
+
+For more information about getting a wallet and the different types of wallets, check the article: [How do I get a wallet?](/dogepedia/articles/how-do-i-get-a-wallet/).
+
+


### PR DESCRIPTION
Hello,

still working on the "recovering wallet" article, but meanwhile I have adjustments (small, but important) that expand a bit a couple of articles I need to link to from that one.

Mostly added an additional option (important) for backing up Dogecoin Core. We might need to add a section for Multidoge in the future, but this is it for now.