### PR TITLE
Remove preview.dogecoin.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,3 +1,2 @@
 dogecoin.com
 www.dogecoin.com
-preview.dogecoin.com

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,3 +1,2 @@
 dogecoin.com
 www.dogecoin.com
-preview.dogecoin.com


### PR DESCRIPTION
Removing preview.dogecoin.com from CNAME file because it does nto support multiple.
We have to create a separeted Repository for preview.dogecoin.com or create an URL redirect on the domain registrar from preview.dogecoin.com to dogecoin.com