### PR TITLE
Update Dogeathon button color

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/menu.html
+++ b/themes/hello-friend-ng/layouts/partials/menu.html
@@ -50,7 +50,7 @@
     {{ else }}
     <li><a href="{{ .URL | relLangURL }}" class="comic-neue tooltip-body-sub">{{ .Name }}</a></li>
     {{ end }} {{- end }}
-    <a href="/dogeathon" class="dogeathon"><li style="background-image: url(/assets/images/hackathon.png); background-size: contain; background-repeat: no-repeat; background-color: #FFAA20; border-radius: 10px; padding: 5px 10px 5px 35px">Dogeathon</li></a>
+    <a href="/dogeathon" class="dogeathon"><li style="background-image: url(/assets/images/hackathon.png); background-size: contain; background-repeat: no-repeat; background-color: #dfc66d; border-radius: 10px; padding: 5px 10px 5px 35px">Dogeathon</li></a>
     <li><a href="https://dogecoinswag.store/" class="comic-neue tooltip-body-sub" target="_blank" ><i class="fa-solid fa-shirt dogecoinswagicon"></i> <span class="dogecoinswag"> Dogecoin<span style="color: rgba(255, 0, 153, 1)">Swag</span></span></a></li>
   </ul>
 </nav>


### PR DESCRIPTION
The Dogeathon icon in navigation menu does not use the consistent brand colouring as seen in the logo and buttons - #dfc66d

![dogeathon before](https://user-images.githubusercontent.com/38789408/189830995-911cbde9-b7b7-4cea-915a-4143ef741045.png)


This proposed change edits the background color to be #dfc66d which is consistent with buttons and the logo as seen below:
![dogeathon after](https://user-images.githubusercontent.com/38789408/189831103-a6e9e456-1b6d-4a69-8255-c798bd86cb53.png)
