### PR TITLE
Fixed typo affecting class name of ‘PT-PT’ locale.

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/locale.html
+++ b/themes/hello-friend-ng/layouts/partials/locale.html
@@ -16,7 +16,7 @@
           {{ if eq (.Lang) "pt-pt"}}
           <div class="lang">
               <span class="flag flag-icon flag-icon-pt"></span>
-              <span class="badge bg-dark text-ligh comic-neuet">{{(.Lang)}}</span>
+              <span class="badge bg-dark text-light comic-neuet">{{(.Lang)}}</span>
           </div>
           {{ else }}
           <div class="lang">

--- a/themes/hello-friend-ng/layouts/partials/locale.html
+++ b/themes/hello-friend-ng/layouts/partials/locale.html
@@ -16,7 +16,7 @@
           {{ if eq (.Lang) "pt-pt"}}
           <div class="lang">
               <span class="flag flag-icon flag-icon-pt"></span>
-              <span class="badge bg-dark text-light comic-neuet">{{(.Lang)}}</span>
+              <span class="badge bg-dark text-light comic-neue">{{(.Lang)}}</span>
           </div>
           {{ else }}
           <div class="lang">


### PR DESCRIPTION
PT-PT locale: ‘badge bg-dark text-light comic-neue’ missing one letter. Typo causes incorrect class output.