### PR TITLE
Update to show that the foundation no longer has any intention of trademarking the name dogecoin and its logos

### DIFF
--- a/content/en/trademarks.md
+++ b/content/en/trademarks.md
@@ -75,7 +75,6 @@ registration deadlines! However, they ultimately protect our community and the D
 against misuse and exploitation.
 Trademarks held by the genuine entity, means the logo and name can be better protected from
 misuse and made available as appropriate under transparent and accessible terms.
-The following is a temporary text and is subject to be changed but still conveys the intentions of the foundation going forward.
 However as an alternative conclusion the Foundation has achieved the aim of stopping anyone from being able to register it.
 It has been determined as a 'generic mark' so now the Foundation has grounds to contest registration and will not be attempting
 to register the trademark and logo of dogecoin again going forward


### PR DESCRIPTION
tagging @jwiechers i think i need a review from you
I have been told that as an alternative conclusion to the foundation registering the dogecoin name and logo trademark the foundation has created grounds to contest registration of the dogecoin trademark and will no longer be attempting to trademark it.
I am not certain of when this alternative has been considered, if it had been considered always or only was considered later down the line. So I have deliberately worded it to not include when this had been considered from and to confirm that the dogecoin foundation has no intention to attempt registering trademark of the name dogecoin and its logo going forward