### PR TITLE
Fix GitHub action deployment complaint

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
Website deployment (specifically the gh action responsible for building and deploying via gh-pages) is failing with err:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details
```

It seems that since we have this project a taste of ubuntu 22.04, reverting back to 20.04 is an issue.