### PR TITLE
Allow case insensitive route matching

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,7 @@ buildDrafts  = false
 buildFuture  = false
 buildExpired = false
 canonifyURLs = true
+caseInsensitiveURLs = true
 
 enableRobotsTXT = true
 enableGitInfo   = false


### PR DESCRIPTION
This PR ensures people visiting dogecoin.com/Devlin (the fundraiser page) are not met with a 404, instead are directed to the correct page.